### PR TITLE
Fix loop in common resource navigation

### DIFF
--- a/plugin/vikube.vim
+++ b/plugin/vikube.vim
@@ -208,7 +208,7 @@ let g:kubernetes_common_resource_types = [
       \"replicasets",
       \"deployments",
       \"endpoints",
-      \"replicasets",
+      \"daemonsets",
       \"services",
       \"serviceaccounts"]
 


### PR DESCRIPTION
**Issue description**: In VikubeExplorer, using `[[` and `]]` when reaching
the replicasets will result in loop ( replicasets -> deployments ->
endpoints -> replicasets) and items skip (services -> replicasets ->
statefulsets), respectively.

**Proposed fix**: I'm not sure of the resource type to be replaced here so
just another common controller(daemonsets). I'm willing to discuss if
you think other resources should be appended or just remove it would be
more appropriate.

Thanks for a lot for making these helpful scripts.